### PR TITLE
Don't dereference null pointers

### DIFF
--- a/src/3rdparty/poly2tri/sweep/sweep.cpp
+++ b/src/3rdparty/poly2tri/sweep/sweep.cpp
@@ -64,12 +64,14 @@ void Sweep::FinalizationPolygon(SweepContext& tcx)
   // Get an Internal triangle to start with
   Triangle* t = tcx.front()->head()->next->triangle;
   Point* p = tcx.front()->head()->next->point;
-  while (!t->GetConstrainedEdgeCW(*p)) {
+  while (p && t && !t->GetConstrainedEdgeCW(*p)) {
     t = t->NeighborCCW(*p);
   }
 
   // Collect interior triangles constrained by edges
-  tcx.MeshClean(*t);
+  if (t) {
+    tcx.MeshClean(*t);
+  }
 }
 
 Node& Sweep::PointEvent(SweepContext& tcx, Point& point)


### PR DESCRIPTION
Potential crash place. This is hard to reproduce, at least I didn't manage, so this might actually lead to a wrong state afterwards. However, backtrace indicated that in sweep.cpp at line 67 null pointer was dereferenced. Root cause like much earlier.
#0  p2t::Triangle::GetConstrainedEdgeCW (this=0x0, p=...) at common/shapes.cpp:271
#1  0x4666ff7c in p2t::Sweep::FinalizationPolygon (this=<optimized out>, tcx=...) at sweep/sweep.cpp:67
#2  0x4667189c in p2t::Sweep::Triangulate (this=0x5064f9f0, tcx=...) at sweep/sweep.cpp:48

@sletta @rburchell 
