### PR TITLE
Fix polygon triangulation crash

### DIFF
--- a/src/3rdparty/poly2tri/common/shapes.h
+++ b/src/3rdparty/poly2tri/common/shapes.h
@@ -254,7 +254,7 @@ inline bool operator ==(const Point& a, const Point& b)
 
 inline bool operator !=(const Point& a, const Point& b)
 {
-  return a.x != b.x && a.y != b.y;
+  return !(a.x == b.x) && !(a.y == b.y);
 }
 
 /// Peform the dot product on two vectors.

--- a/src/3rdparty/poly2tri/common/shapes.h
+++ b/src/3rdparty/poly2tri/common/shapes.h
@@ -44,7 +44,7 @@ struct Edge;
 
 struct Point {
 
-  float x, y;
+  double x, y;
 
   /// Default constructor does nothing (for performance).
   Point()
@@ -57,7 +57,7 @@ struct Point {
   std::vector<Edge*> edge_list;
 
   /// Construct using coordinates.
-  Point(float x, float y) : x(x), y(y) {}
+  Point(double x, double y) : x(x), y(y) {}
 
   /// Set this point to all zeros.
   void set_zero()
@@ -67,7 +67,7 @@ struct Point {
   }
 
   /// Set this point to some specified coordinates.
-  void set(float x_, float y_)
+  void set(double x_, double y_)
   {
     x = x_;
     y = y_;
@@ -96,22 +96,22 @@ struct Point {
   }
 
   /// Multiply this point by a scalar.
-  void operator *=(float a)
+  void operator *=(double a)
   {
     x *= a;
     y *= a;
   }
 
   /// Get the length of this point (the norm).
-  float Length() const
+  double Length() const
   {
     return std::sqrt(x * x + y * y);
   }
 
   /// Convert this point into a unit point. Returns the Length.
-  float Normalize()
+  double Normalize()
   {
-    float len = Length();
+    double len = Length();
     x /= len;
     y /= len;
     return len;
@@ -242,7 +242,7 @@ inline Point operator -(const Point& a, const Point& b)
 }
 
 /// Multiply point by scalar
-inline Point operator *(float s, const Point& a)
+inline Point operator *(double s, const Point& a)
 {
   return Point(s * a.x, s * a.y);
 }
@@ -258,27 +258,27 @@ inline bool operator !=(const Point& a, const Point& b)
 }
 
 /// Peform the dot product on two vectors.
-inline float Dot(const Point& a, const Point& b)
+inline double Dot(const Point& a, const Point& b)
 {
   return a.x * b.x + a.y * b.y;
 }
 
 /// Perform the cross product on two vectors. In 2D this produces a scalar.
-inline float Cross(const Point& a, const Point& b)
+inline double Cross(const Point& a, const Point& b)
 {
   return a.x * b.y - a.y * b.x;
 }
 
 /// Perform the cross product on a point and a scalar. In 2D this produces
 /// a point.
-inline Point Cross(const Point& a, float s)
+inline Point Cross(const Point& a, double s)
 {
   return Point(s * a.y, -s * a.x);
 }
 
 /// Perform the cross product on a scalar and a point. In 2D this produces
 /// a point.
-inline Point Cross(const float s, const Point& a)
+inline Point Cross(const double s, const Point& a)
 {
   return Point(-s * a.y, s * a.x);
 }

--- a/src/3rdparty/poly2tri/common/utils.h
+++ b/src/3rdparty/poly2tri/common/utils.h
@@ -44,9 +44,9 @@
 
 namespace p2t {
 
-const float PI_3div4 = 3 * M_PI / 4;
-const float PI_div2 = 1.57079632679489661923;
-const float EPSILON = 1e-12;
+const double PI_3div4 = 3 * M_PI / 4;
+const double PI_div2 = 1.57079632679489661923;
+const double EPSILON = 1e-12;
 
 enum Orientation { CW, CCW, COLLINEAR };
 
@@ -62,9 +62,9 @@ enum Orientation { CW, CCW, COLLINEAR };
  */
 Orientation Orient2d(Point& pa, Point& pb, Point& pc)
 {
-  float detleft = (pa.x - pc.x) * (pb.y - pc.y);
-  float detright = (pa.y - pc.y) * (pb.x - pc.x);
-  float val = detleft - detright;
+  double detleft = (pa.x - pc.x) * (pb.y - pc.y);
+  double detright = (pa.y - pc.y) * (pb.x - pc.x);
+  double val = detleft - detright;
   if (val > -EPSILON && val < EPSILON) {
     return COLLINEAR;
   } else if (val > 0) {
@@ -76,27 +76,27 @@ Orientation Orient2d(Point& pa, Point& pb, Point& pc)
 /*
 bool InScanArea(Point& pa, Point& pb, Point& pc, Point& pd)
 {
-  float pdx = pd.x;
-  float pdy = pd.y;
-  float adx = pa.x - pdx;
-  float ady = pa.y - pdy;
-  float bdx = pb.x - pdx;
-  float bdy = pb.y - pdy;
+  double pdx = pd.x;
+  double pdy = pd.y;
+  double adx = pa.x - pdx;
+  double ady = pa.y - pdy;
+  double bdx = pb.x - pdx;
+  double bdy = pb.y - pdy;
 
-  float adxbdy = adx * bdy;
-  float bdxady = bdx * ady;
-  float oabd = adxbdy - bdxady;
+  double adxbdy = adx * bdy;
+  double bdxady = bdx * ady;
+  double oabd = adxbdy - bdxady;
 
   if (oabd <= EPSILON) {
     return false;
   }
 
-  float cdx = pc.x - pdx;
-  float cdy = pc.y - pdy;
+  double cdx = pc.x - pdx;
+  double cdy = pc.y - pdy;
 
-  float cdxady = cdx * ady;
-  float adxcdy = adx * cdy;
-  float ocad = cdxady - adxcdy;
+  double cdxady = cdx * ady;
+  double adxcdy = adx * cdy;
+  double ocad = cdxady - adxcdy;
 
   if (ocad <= EPSILON) {
     return false;
@@ -109,12 +109,12 @@ bool InScanArea(Point& pa, Point& pb, Point& pc, Point& pd)
 
 bool InScanArea(Point& pa, Point& pb, Point& pc, Point& pd)
 {
-  float oadb = (pa.x - pb.x)*(pd.y - pb.y) - (pd.x - pb.x)*(pa.y - pb.y);
+  double oadb = (pa.x - pb.x)*(pd.y - pb.y) - (pd.x - pb.x)*(pa.y - pb.y);
   if (oadb >= -EPSILON) {
     return false;
   }
 
-  float oadc = (pa.x - pc.x)*(pd.y - pc.y) - (pd.x - pc.x)*(pa.y - pc.y);
+  double oadc = (pa.x - pc.x)*(pd.y - pc.y) - (pd.x - pc.x)*(pa.y - pc.y);
   if (oadc <= EPSILON) {
     return false;
   }

--- a/src/3rdparty/poly2tri/sweep/advancing_front.cpp
+++ b/src/3rdparty/poly2tri/sweep/advancing_front.cpp
@@ -39,7 +39,7 @@ AdvancingFront::AdvancingFront(Node& head, Node& tail)
   search_node_ = &head;
 }
 
-Node* AdvancingFront::LocateNode(const float& x)
+Node* AdvancingFront::LocateNode(const double& x)
 {
   Node* node = search_node_;
 
@@ -61,7 +61,7 @@ Node* AdvancingFront::LocateNode(const float& x)
   return NULL;
 }
 
-Node* AdvancingFront::FindSearchNode(const float& x)
+Node* AdvancingFront::FindSearchNode(const double& x)
 {
   (void)x; // suppress compiler warnings "unused parameter 'x'"
   // TODO: implement BST index
@@ -70,9 +70,9 @@ Node* AdvancingFront::FindSearchNode(const float& x)
 
 Node* AdvancingFront::LocatePoint(const Point* point)
 {
-  const float px = point->x;
+  const double px = point->x;
   Node* node = FindSearchNode(px);
-  const float nx = node->point->x;
+  const double nx = node->point->x;
 
   if (px == nx) {
     if (point != node->point) {

--- a/src/3rdparty/poly2tri/sweep/advancing_front.h
+++ b/src/3rdparty/poly2tri/sweep/advancing_front.h
@@ -46,7 +46,7 @@ struct Node {
   Node* next;
   Node* prev;
 
-  float value;
+  double value;
 
   Node(Point& p) : point(&p), triangle(NULL), next(NULL), prev(NULL), value(p.x)
   {
@@ -74,7 +74,7 @@ Node* search();
 void set_search(Node* node);
 
 /// Locate insertion point along advancing front
-Node* LocateNode(const float& x);
+Node* LocateNode(const double& x);
 
 Node* LocatePoint(const Point* point);
 
@@ -82,7 +82,7 @@ private:
 
 Node* head_, *tail_, *search_node_;
 
-Node* FindSearchNode(const float& x);
+Node* FindSearchNode(const double& x);
 };
 
 inline Node* AdvancingFront::head()

--- a/src/3rdparty/poly2tri/sweep/sweep.cpp
+++ b/src/3rdparty/poly2tri/sweep/sweep.cpp
@@ -244,7 +244,7 @@ void Sweep::FillAdvancingFront(SweepContext& tcx, Node& n)
 
   // Fill right basins
   if (n.next && n.next->next) {
-    float angle = BasinAngle(n);
+    double angle = BasinAngle(n);
     if (angle < PI_3div4) {
       FillBasin(tcx, n);
     }
@@ -274,18 +274,18 @@ bool Sweep::LargeHole_DontFill(Node* node) {
 }
 
 bool Sweep::AngleExceeds90Degrees(Point* origin, Point* pa, Point* pb) {
-  float angle = Angle(*origin, *pa, *pb);
+  double angle = Angle(*origin, *pa, *pb);
   bool exceeds90Degrees = ((angle > PI_div2) || (angle < -PI_div2));
   return exceeds90Degrees;
 }
 
 bool Sweep::AngleExceedsPlus90DegreesOrIsNegative(Point* origin, Point* pa, Point* pb) {
-  float angle = Angle(*origin, *pa, *pb);
+  double angle = Angle(*origin, *pa, *pb);
   bool exceedsPlus90DegreesOrIsNegative = (angle > PI_div2) || (angle < 0);
   return exceedsPlus90DegreesOrIsNegative;
 }
 
-float Sweep::Angle(Point& origin, Point& pa, Point& pb) {
+double Sweep::Angle(Point& origin, Point& pa, Point& pb) {
   /* Complex plane
    * ab = cosA +i*sinA
    * ab = (ax + ay*i)(bx + by*i) = (ax*bx + ay*by) + i(ax*by-ay*bx)
@@ -294,26 +294,26 @@ float Sweep::Angle(Point& origin, Point& pa, Point& pb) {
    * Where x = ax*bx + ay*by
    *       y = ax*by - ay*bx
    */
-  float px = origin.x;
-  float py = origin.y;
-  float ax = pa.x- px;
-  float ay = pa.y - py;
-  float bx = pb.x - px;
-  float by = pb.y - py;
-  float x = ax * by - ay * bx;
-  float y = ax * bx + ay * by;
-  float angle = atan2(x, y);
+  double px = origin.x;
+  double py = origin.y;
+  double ax = pa.x- px;
+  double ay = pa.y - py;
+  double bx = pb.x - px;
+  double by = pb.y - py;
+  double x = ax * by - ay * bx;
+  double y = ax * bx + ay * by;
+  double angle = atan2(x, y);
   return angle;
 }
 
-float Sweep::BasinAngle(Node& node)
+double Sweep::BasinAngle(Node& node)
 {
-  float ax = node.point->x - node.next->next->point->x;
-  float ay = node.point->y - node.next->next->point->y;
+  double ax = node.point->x - node.next->next->point->x;
+  double ay = node.point->y - node.next->next->point->y;
   return atan2(ay, ax);
 }
 
-float Sweep::HoleAngle(Node& node)
+double Sweep::HoleAngle(Node& node)
 {
   /* Complex plane
    * ab = cosA +i*sinA
@@ -323,10 +323,10 @@ float Sweep::HoleAngle(Node& node)
    * Where x = ax*bx + ay*by
    *       y = ax*by - ay*bx
    */
-  float ax = node.next->point->x - node.point->x;
-  float ay = node.next->point->y - node.point->y;
-  float bx = node.prev->point->x - node.point->x;
-  float by = node.prev->point->y - node.point->y;
+  double ax = node.next->point->x - node.point->x;
+  double ay = node.next->point->y - node.point->y;
+  double bx = node.prev->point->x - node.point->x;
+  double by = node.prev->point->y - node.point->y;
   return atan2(ax * by - ay * bx, ax * bx + ay * by);
 }
 
@@ -393,36 +393,36 @@ bool Sweep::Legalize(SweepContext& tcx, Triangle& t)
 
 bool Sweep::Incircle(Point& pa, Point& pb, Point& pc, Point& pd)
 {
-  float adx = pa.x - pd.x;
-  float ady = pa.y - pd.y;
-  float bdx = pb.x - pd.x;
-  float bdy = pb.y - pd.y;
+  double adx = pa.x - pd.x;
+  double ady = pa.y - pd.y;
+  double bdx = pb.x - pd.x;
+  double bdy = pb.y - pd.y;
 
-  float adxbdy = adx * bdy;
-  float bdxady = bdx * ady;
-  float oabd = adxbdy - bdxady;
+  double adxbdy = adx * bdy;
+  double bdxady = bdx * ady;
+  double oabd = adxbdy - bdxady;
 
   if (oabd <= 0)
     return false;
 
-  float cdx = pc.x - pd.x;
-  float cdy = pc.y - pd.y;
+  double cdx = pc.x - pd.x;
+  double cdy = pc.y - pd.y;
 
-  float cdxady = cdx * ady;
-  float adxcdy = adx * cdy;
-  float ocad = cdxady - adxcdy;
+  double cdxady = cdx * ady;
+  double adxcdy = adx * cdy;
+  double ocad = cdxady - adxcdy;
 
   if (ocad <= 0)
     return false;
 
-  float bdxcdy = bdx * cdy;
-  float cdxbdy = cdx * bdy;
+  double bdxcdy = bdx * cdy;
+  double cdxbdy = cdx * bdy;
 
-  float alift = adx * adx + ady * ady;
-  float blift = bdx * bdx + bdy * bdy;
-  float clift = cdx * cdx + cdy * cdy;
+  double alift = adx * adx + ady * ady;
+  double blift = bdx * bdx + bdy * bdy;
+  double clift = cdx * cdx + cdy * cdy;
 
-  float det = alift * (bdxcdy - cdxbdy) + blift * ocad + clift * oabd;
+  double det = alift * (bdxcdy - cdxbdy) + blift * ocad + clift * oabd;
 
   return det > 0;
 }
@@ -548,7 +548,7 @@ void Sweep::FillBasinReq(SweepContext& tcx, Node* node)
 
 bool Sweep::IsShallow(SweepContext& tcx, Node& node)
 {
-  float height;
+  double height;
 
   if (tcx.basin.left_highest) {
     height = tcx.basin.left_node->point->y - node.point->y;

--- a/src/3rdparty/poly2tri/sweep/sweep.h
+++ b/src/3rdparty/poly2tri/sweep/sweep.h
@@ -174,19 +174,19 @@ private:
   bool LargeHole_DontFill(Node* node);
   bool AngleExceeds90Degrees(Point* origin, Point* pa, Point* pb);
   bool AngleExceedsPlus90DegreesOrIsNegative(Point* origin, Point* pa, Point* pb);
-  float Angle(Point& origin, Point& pa, Point& pb);
+  double Angle(Point& origin, Point& pa, Point& pb);
 
   /**
    *
    * @param node - middle node
    * @return the angle between 3 front nodes
    */
-  float HoleAngle(Node& node);
+  double HoleAngle(Node& node);
 
   /**
    * The basin angle is decided against the horizontal line [1,0]
    */
-  float BasinAngle(Node& node);
+  double BasinAngle(Node& node);
 
   /**
    * Fills a basin that has formed on the Advancing Front to the right

--- a/src/3rdparty/poly2tri/sweep/sweep_context.cpp
+++ b/src/3rdparty/poly2tri/sweep/sweep_context.cpp
@@ -34,7 +34,13 @@
 
 namespace p2t {
 
-SweepContext::SweepContext(std::vector<Point*> polyline)
+SweepContext::SweepContext(std::vector<Point*> polyline) :
+  front_(0),
+  head_(0),
+  tail_(0),
+  af_head_(0),
+  af_middle_(0),
+  af_tail_(0)
 {
   basin = Basin();
   edge_event = EdgeEvent();
@@ -164,12 +170,20 @@ void SweepContext::RemoveFromMap(Triangle* triangle)
 
 void SweepContext::MeshClean(Triangle& triangle)
 {
-  if (&triangle != NULL && !triangle.IsInterior()) {
-    triangle.IsInterior(true);
-    triangles_.push_back(&triangle);
-    for (int i = 0; i < 3; i++) {
-      if (!triangle.constrained_edge[i])
-        MeshClean(*triangle.GetNeighbor(i));
+  std::vector<Triangle *> triangles;
+  triangles.push_back(&triangle);
+
+  while(!triangles.empty()){
+	Triangle *t = triangles.back();
+	triangles.pop_back();
+
+    if (t != NULL && !t->IsInterior()) {
+      t->IsInterior(true);
+      triangles_.push_back(t);
+      for (int i = 0; i < 3; i++) {
+        if (!t->constrained_edge[i])
+          triangles.push_back(t->GetNeighbor(i));
+      }
     }
   }
 }

--- a/src/3rdparty/poly2tri/sweep/sweep_context.cpp
+++ b/src/3rdparty/poly2tri/sweep/sweep_context.cpp
@@ -74,8 +74,8 @@ std::list<Triangle*> SweepContext::GetMap()
 
 void SweepContext::InitTriangulation()
 {
-  float xmax(points_[0]->x), xmin(points_[0]->x);
-  float ymax(points_[0]->y), ymin(points_[0]->y);
+  double xmax(points_[0]->x), xmin(points_[0]->x);
+  double ymax(points_[0]->y), ymin(points_[0]->y);
 
   // Calculate bounds.
   for (unsigned int i = 0; i < points_.size(); i++) {
@@ -90,8 +90,8 @@ void SweepContext::InitTriangulation()
       ymin = p.y;
   }
 
-  float dx = kAlpha * (xmax - xmin);
-  float dy = kAlpha * (ymax - ymin);
+  double dx = kAlpha * (xmax - xmin);
+  double dy = kAlpha * (ymax - ymin);
   head_ = new Point(xmax + dx, ymin - dy);
   tail_ = new Point(xmin - dx, ymin - dy);
 

--- a/src/3rdparty/poly2tri/sweep/sweep_context.h
+++ b/src/3rdparty/poly2tri/sweep/sweep_context.h
@@ -40,7 +40,7 @@ namespace p2t {
 
 // Inital triangle factor, seed triangle will extend 30% of
 // PointSet width to both left and right.
-const float kAlpha = float(0.3);
+const double kAlpha = 0.3;
 
 struct Point;
 class Triangle;
@@ -100,7 +100,7 @@ struct Basin {
   Node* left_node;
   Node* bottom_node;
   Node* right_node;
-  float width;
+  double width;
   bool left_highest;
 
   Basin() : left_node(NULL), bottom_node(NULL), right_node(NULL), width(0.0), left_highest(false)


### PR DESCRIPTION
Fix crash in poly2tri due to insufficient floating point precision. This should render https://github.com/mer-qt/qtlocation/pull/5 unnecessary.
