### PR TITLE
Avoid map polyline/route/polygon draw around half the world

### DIFF
--- a/src/imports/location/qdeclarativepolygonmapitem.cpp
+++ b/src/imports/location/qdeclarativepolygonmapitem.cpp
@@ -183,7 +183,9 @@ void QGeoMapPolygonGeometry::updateSourcePoints(const QGeoMap &map,
             return;
 
         // unwrap x to preserve geometry if moved to border of map
-        if (preserveGeometry_ && point.x() < unwrapBelowX && !qFuzzyCompare(point.x(), unwrapBelowX))
+        if (preserveGeometry_ && point.x() < unwrapBelowX
+                && !qFuzzyCompare(point.x(), unwrapBelowX)
+                && !qFuzzyCompare(geoLeftBound_.longitude(), coord.longitude()))
             point.setX(unwrapBelowX + geoDistanceToScreenWidth(map, geoLeftBound_, coord));
 
         if (i == 0) {

--- a/src/imports/location/qdeclarativepolylinemapitem.cpp
+++ b/src/imports/location/qdeclarativepolylinemapitem.cpp
@@ -225,7 +225,9 @@ void QGeoMapPolylineGeometry::updateSourcePoints(const QGeoMap &map,
             return;
 
         // unwrap x to preserve geometry if moved to border of map
-        if (preserveGeometry_ && point.x() < unwrapBelowX && !qFuzzyCompare(point.x(), unwrapBelowX))
+        if (preserveGeometry_ && point.x() < unwrapBelowX
+                && !qFuzzyCompare(geoLeftBound_.longitude(), coord.longitude())
+                && !qFuzzyCompare(point.x(), unwrapBelowX))
             point.setX(unwrapBelowX + geoDistanceToScreenWidth(map, geoLeftBound_, coord));
 
         if (!foundValid) {

--- a/src/imports/location/qgeomapitemgeometry.cpp
+++ b/src/imports/location/qgeomapitemgeometry.cpp
@@ -132,6 +132,9 @@ double QGeoMapItemGeometry::geoDistanceToScreenWidth(const QGeoMap &map,
                                                      const QGeoCoordinate &fromCoord,
                                                      const QGeoCoordinate &toCoord)
 {
+    // Do not wrap around half the globe
+    Q_ASSERT(!qFuzzyCompare(fromCoord.longitude(), toCoord.longitude()));
+
     QGeoCoordinate mapMid = map.screenPositionToCoordinate(QDoubleVector2D(map.width()/2.0, 0));
     double halfGeoDist = toCoord.longitude() - fromCoord.longitude();
     if (toCoord.longitude() < fromCoord.longitude())


### PR DESCRIPTION
This is triggered when the longitude difference between two coordinates
is 0 which causes an artificial wrap around half the world.

The already existing fuzzyness check between the coordinate's pixel
positions is not sufficient. The conversion from geo coordinates
into pixels involves math which can trigger larger pixel differences
despite relatively tiny longitude differences. On the other hand the
to be called geoDistanceToScreenWidth() function already wraps when
the longitudes have a close enough value.

Task-number: QTBUG-43107
Change-Id: I0b1432e47240e9911e77a0e53e74f560356eee4b
Reviewed-by: Michal Klocek michal.klocek@digia.com
Reviewed-by: Aaron McCarthy mccarthy.aaron@gmail.com
