### PR TITLE
Limit the minimum zoom level based on tile size and map item size.

### DIFF
--- a/src/imports/location/qdeclarativegeomap_p.h
+++ b/src/imports/location/qdeclarativegeomap_p.h
@@ -197,6 +197,7 @@ private Q_SLOTS:
     void mapBearingChanged(qreal bearing);
     void pluginReady();
     void onMapChildrenChanged();
+    void onMinimumZoomLevelChanged();
 
 private:
     void setupMapView(QDeclarativeGeoMapItemView *view);

--- a/src/location/maps/qgeomap.cpp
+++ b/src/location/maps/qgeomap.cpp
@@ -76,6 +76,7 @@ QGeoMap::QGeoMap(QGeoMapData *mapData, QObject *parent)
     connect(mapData_, SIGNAL(updateRequired()), this, SIGNAL(updateRequired()));
     connect(mapData_, SIGNAL(activeMapTypeChanged()), this, SIGNAL(activeMapTypeChanged()));
     connect(mapData_, SIGNAL(copyrightsChanged(const QImage&, const QPoint&)), this, SIGNAL(copyrightsChanged(const QImage&, const QPoint&)));
+    connect(mapData_, SIGNAL(minimumZoomChanged()), this, SIGNAL(minimumZoomChanged()));
 }
 
 QGeoMap::~QGeoMap()
@@ -156,6 +157,11 @@ const QGeoMapType QGeoMap::activeMapType() const
 QString QGeoMap::pluginString()
 {
     return mapData_->pluginString();
+}
+
+qreal QGeoMap::minimumZoom() const
+{
+    return mapData_->minimumZoom();
 }
 
 QT_END_NAMESPACE

--- a/src/location/maps/qgeomap_p.h
+++ b/src/location/maps/qgeomap_p.h
@@ -105,6 +105,8 @@ public:
 
     QString pluginString();
 
+    qreal minimumZoom() const;
+
 public Q_SLOTS:
     void update();
     void cameraStopped(); // optional hint for prefetch
@@ -114,6 +116,7 @@ Q_SIGNALS:
     void updateRequired();
     void activeMapTypeChanged();
     void copyrightsChanged(const QImage &copyrightsImage, const QPoint &copyrightsPos);
+    void minimumZoomChanged();
 
 private:
     QGeoMapData *mapData_;

--- a/src/location/maps/qgeomapdata.cpp
+++ b/src/location/maps/qgeomapdata.cpp
@@ -159,10 +159,23 @@ QGeoMappingManagerEngine *QGeoMapData::engine()
     return d->engine();
 }
 
+void QGeoMapData::setMinimumZoom(qreal zoom)
+{
+    Q_D(QGeoMapData);
+    d->setMinimumZoom(zoom);
+}
+
+qreal QGeoMapData::minimumZoom() const
+{
+    Q_D(const QGeoMapData);
+    return d->minimumZoom();
+}
+
 QGeoMapDataPrivate::QGeoMapDataPrivate(QGeoMappingManagerEngine *engine, QGeoMapData *parent)
     : width_(0),
       height_(0),
       aspectRatio_(0.0),
+      minimumZoom_(0),
       map_(parent),
       engine_(engine),
       controller_(0),
@@ -187,6 +200,20 @@ QGeoMappingManagerEngine *QGeoMapDataPrivate::engine() const
 QString QGeoMapDataPrivate::pluginString()
 {
     return pluginString_;
+}
+
+void QGeoMapDataPrivate::setMinimumZoom(qreal zoom)
+{
+    if (minimumZoom_ == zoom)
+        return;
+
+    minimumZoom_ = zoom;
+    emit map_->minimumZoomChanged();
+}
+
+qreal QGeoMapDataPrivate::minimumZoom() const
+{
+    return minimumZoom_;
 }
 
 QGeoMapController *QGeoMapDataPrivate::mapController()

--- a/src/location/maps/qgeomapdata_p.h
+++ b/src/location/maps/qgeomapdata_p.h
@@ -104,6 +104,9 @@ public:
     QGeoMappingManagerEngine *engine();
     virtual void prefetchData() {}
 
+    void setMinimumZoom(qreal zoom);
+    qreal minimumZoom() const;
+
 protected:
     virtual void mapResized(int width, int height) = 0;
     virtual void changeCameraData(const QGeoCameraData &oldCameraData) = 0;
@@ -117,6 +120,7 @@ Q_SIGNALS:
     void updateRequired();
     void activeMapTypeChanged();
     void copyrightsChanged(const QImage &copyrightsImage, const QPoint &copyrightsPos);
+    void minimumZoomChanged();
 
 private:
     QGeoMapDataPrivate *d_ptr;

--- a/src/location/maps/qgeomapdata_p_p.h
+++ b/src/location/maps/qgeomapdata_p_p.h
@@ -96,10 +96,14 @@ public:
     void setActiveMapType(const QGeoMapType &mapType);
     QString pluginString();
 
+    void setMinimumZoom(qreal zoom);
+    qreal minimumZoom() const;
+
 private:
     int width_;
     int height_;
     double aspectRatio_;
+    qreal minimumZoom_;
 
     QGeoMapData *map_;
     QGeoMappingManagerEngine *engine_;

--- a/src/location/maps/qgeotiledmapdata.cpp
+++ b/src/location/maps/qgeotiledmapdata.cpp
@@ -302,6 +302,13 @@ void QGeoTiledMapDataPrivate::resized(int width, int height)
         int newSize = qMax(cache_->minTextureUsage(), texCacheSize);
         cache_->setMinTextureUsage(newSize);
     }
+
+    // Calculate the minimum zoom based on tileSize and scene height/width, preventing the map
+    // being zoomed smaller than the map item.
+    if (height >= width)
+        map_->setMinimumZoom(log2(qreal(height) / engine_->tileSize().height()));
+    else
+        map_->setMinimumZoom(log2(qreal(width) / engine_->tileSize().width()));
 }
 
 void QGeoTiledMapDataPrivate::newTileFetched(const QGeoTileSpec &spec)


### PR DESCRIPTION
Depending on the size of the map item the minimum zoom supported by the
plugin may be such that empty gray borders are shown around the map when
zoomed out. Limit the minimum zoom, for tiled maps, so that those
borders are not shown.

A related problem also exists which is not affected by this change. It
is not always possible to zoom out far enough to see the full view of
at least one dimension. Fixing this is a more extensive change requiring
supporting zoom levels less than supported by the plugin, even negative
zoom levels.

[ChangeLog][QtLocation][Maps] The minimum zoom level for tile based
maps is now limited based on the size of the map item and the tile size.

Change-Id: I667e86c15a30068198a034aa5020d6a6b99f46b6
